### PR TITLE
fixed a typo in `v-for` iteration with `of` delimiter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ List of 300 VueJS Interview Questions
     2. Object usage:
     ```javascript
     <div id="object">
-      <div v-for="(value, key, index) in user">
+      <div v-for="(value, key, index) of user">
         {{ index }}. {{ key }}: {{ value }}
       </div>
     </div>


### PR DESCRIPTION
Found a typo in: 

You can also use `of` as the delimiter instead of `in`, similar to javascript iterators.

```javascript
    <div id="object">
      <div v-for="(value, key, index) in user">
        {{ index }}. {{ key }}: {{ value }}
      </div>
    </div>

    var vm = new Vue({
      el: '#object',
      data: {
        user: {
          firstName: 'John',
          lastName: 'Locke',
          age: 30
        }
      }
    })
```

`in` delimiter was used in example instead of `of`. 